### PR TITLE
feat(em. controller/outpost): add clawback endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "astroport-emissions-controller-outpost"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "astroport 5.8.0",

--- a/contracts/emissions_controller_outpost/Cargo.toml
+++ b/contracts/emissions_controller_outpost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-emissions-controller-outpost"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Astroport"]
 edition = "2021"
 description = "Astroport vxASTRO Emissions Voting Contract. Outpost version"

--- a/contracts/emissions_controller_outpost/src/migration.rs
+++ b/contracts/emissions_controller_outpost/src/migration.rs
@@ -13,8 +13,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, Contra
 
     match contract_version.contract.as_ref() {
         CONTRACT_NAME => match contract_version.version.as_ref() {
-            "1.0.0" => Ok(()),
-            "1.1.0" => Ok(()),
+            "1.0.0" | "1.1.0" | "1.2.0" => Ok(()),
             _ => Err(ContractError::MigrationError {}),
         },
         _ => Err(ContractError::MigrationError {}),

--- a/contracts/emissions_controller_outpost/tests/common/helper.rs
+++ b/contracts/emissions_controller_outpost/tests/common/helper.rs
@@ -307,15 +307,22 @@ impl ControllerHelper {
         self.app.execute_contract(
             user.clone(),
             self.emission_controller.clone(),
-            &emissions_controller::msg::ExecuteMsg::<OutpostMsg>::Custom(
-                OutpostMsg::PermissionedSetEmissions {
-                    schedules: schedules
-                        .iter()
-                        .map(|(pool, schedule)| (pool.to_string(), schedule.clone()))
-                        .collect(),
-                },
-            ),
+            &ExecuteMsg::<OutpostMsg>::Custom(OutpostMsg::PermissionedSetEmissions {
+                schedules: schedules
+                    .iter()
+                    .map(|(pool, schedule)| (pool.to_string(), schedule.clone()))
+                    .collect(),
+            }),
             funds,
+        )
+    }
+
+    pub fn clawback(&mut self, user: &Addr) -> AnyResult<AppResponse> {
+        self.app.execute_contract(
+            user.clone(),
+            self.emission_controller.clone(),
+            &ExecuteMsg::<OutpostMsg>::Custom(OutpostMsg::ClawbackAstro {}),
+            &[],
         )
     }
 

--- a/packages/astroport-governance/src/emissions_controller/outpost.rs
+++ b/packages/astroport-governance/src/emissions_controller/outpost.rs
@@ -40,6 +40,10 @@ pub enum OutpostMsg {
     PermissionedSetEmissions {
         schedules: Vec<(String, InputSchedule)>,
     },
+    /// Permissioned to the contract owner.
+    /// Allows to clawback ASTRO tokens bridged but not yet used in schedules.
+    /// ASTRO tokens are sent back to the Hub emissions controller.
+    ClawbackAstro {},
     /// Allows using vxASTRO voting power to vote on general DAO proposals.
     /// The contract requires a proposal with specific id to be registered via
     /// a special permissionless IBC message.

--- a/schemas/astroport-emissions-controller-outpost/astroport-emissions-controller-outpost.json
+++ b/schemas/astroport-emissions-controller-outpost/astroport-emissions-controller-outpost.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "astroport-emissions-controller-outpost",
-  "contract_version": "1.2.0",
+  "contract_version": "1.2.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -487,6 +487,20 @@
                     }
                   }
                 },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Permissioned to the contract owner. Allows to clawback ASTRO tokens bridged but not yet used in schedules. ASTRO tokens are sent back to the Hub emissions controller.",
+            "type": "object",
+            "required": [
+              "clawback_astro"
+            ],
+            "properties": {
+              "clawback_astro": {
+                "type": "object",
                 "additionalProperties": false
               }
             },

--- a/schemas/astroport-emissions-controller-outpost/raw/execute.json
+++ b/schemas/astroport-emissions-controller-outpost/raw/execute.json
@@ -325,6 +325,20 @@
           "additionalProperties": false
         },
         {
+          "description": "Permissioned to the contract owner. Allows to clawback ASTRO tokens bridged but not yet used in schedules. ASTRO tokens are sent back to the Hub emissions controller.",
+          "type": "object",
+          "required": [
+            "clawback_astro"
+          ],
+          "properties": {
+            "clawback_astro": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
           "description": "Allows using vxASTRO voting power to vote on general DAO proposals. The contract requires a proposal with specific id to be registered via a special permissionless IBC message.",
           "type": "object",
           "required": [


### PR DESCRIPTION
Obviously only one outpost didn't have IBC hooks - Sei. Since they're going to remove cosmwasm completely we have to rescue our ASTRO from emissions controller 